### PR TITLE
media editor: emoticons icon now visible near text input, now complete reset is avoided when touching outside of the rectangle

### DIFF
--- a/stylesheets/components/Droidian.scss
+++ b/stylesheets/components/Droidian.scss
@@ -129,3 +129,7 @@
 .module-tooltip {
     display: none !important;
 }
+
+.MediaEditor__tools--input {
+    width: 150px;
+}

--- a/ts/components/MediaEditor.dom.tsx
+++ b/ts/components/MediaEditor.dom.tsx
@@ -777,7 +777,7 @@ export function MediaEditor({
         });
 
         rect.on('deselected', () => {
-          setEditMode(undefined);
+          fabricCanvas.setActiveObject(rect);
         });
 
         fabricCanvas.add(rect);


### PR DESCRIPTION
The media editor had two issues that I've solved with this edit

- the emoticons icon was not visible near to the input text
- when clicking outside of the crop rectangle the whole image was reset